### PR TITLE
feat: Dynamic monthly review range for KRs and modal pickers

### DIFF
--- a/prisma/migrations/20250730161416_add_keyresult_created_at/migration.sql
+++ b/prisma/migrations/20250730161416_add_keyresult_created_at/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `KeyResult` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."KeyResult" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20250730161527_created_at/migration.sql
+++ b/prisma/migrations/20250730161527_created_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."KeyResult" ALTER COLUMN "updatedAt" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,8 @@ model KeyResult {
   objectiveId   Int
   successCriteria SuccessCriteria[]
   reviews       KeyResultReview[]
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
 }
 
 model SuccessCriteria {

--- a/src/app/api/objectives/user/route.ts
+++ b/src/app/api/objectives/user/route.ts
@@ -23,12 +23,14 @@ export async function GET(req: Request) {
       guid: true,
       title: true,
       dueDate: true,
+      createdAt: true,
       keyResults: {
         select: {
           id: true,
           title: true,
           metric: true,
           targetValue: true,
+          createdAt: true,
           successCriteria: {
             select: {
               id: true,

--- a/src/app/objectives/review/__tests__/OKRReviewPage.test.tsx
+++ b/src/app/objectives/review/__tests__/OKRReviewPage.test.tsx
@@ -13,12 +13,14 @@ beforeEach(() => {
               guid: "obj-1",
               title: "Grow revenue",
               dueDate: "2025-12-31T00:00:00.000Z",
+              createdAt: "2025-06-01T00:00:00.000Z",
               keyResults: [
                 {
                   id: 1,
                   title: "Increase MRR",
                   metric: "MRR",
                   targetValue: "$100k",
+                  createdAt: "2025-08-01T00:00:00.000Z",
                   successCriteria: [
                     { id: 101, description: "MRR > $90k", threshold: "$90k" },
                     { id: 102, description: "MRR > $80k", threshold: "$80k" },
@@ -29,6 +31,7 @@ beforeEach(() => {
                   title: "Reduce churn",
                   metric: "Churn %",
                   targetValue: "<5%",
+                  // No createdAt, should fallback to obj.createdAt
                   successCriteria: [],
                 },
               ],
@@ -70,5 +73,17 @@ describe("OKRReviewPage", () => {
   it("shows loading state initially", () => {
     render(<OKRReviewPage />);
     expect(screen.getByText(/Loading.../)).toBeInTheDocument();
+  });
+
+  it("renders only correct months for each KR", async () => {
+    render(<OKRReviewPage />);
+    await waitFor(() => expect(screen.getByText(/KR 1: Increase MRR/)).toBeInTheDocument());
+    // Should show Aug 2025 to Dec 2025 for KR 1
+    expect(screen.getByText("Aug 2025")).toBeInTheDocument();
+    expect(screen.getByText("Dec 2025")).toBeInTheDocument();
+    expect(screen.queryByText("Jul 2025")).not.toBeInTheDocument();
+    // Should show Jun 2025 to Dec 2025 for KR 2 (fallback to obj.createdAt)
+    expect(screen.getByText("Jun 2025")).toBeInTheDocument();
+    expect(screen.getByText("Dec 2025")).toBeInTheDocument();
   });
 });

--- a/src/app/objectives/review/__tests__/OKRReviewPageModal.test.tsx
+++ b/src/app/objectives/review/__tests__/OKRReviewPageModal.test.tsx
@@ -13,17 +13,19 @@ beforeEach(() => {
               guid: "obj-1",
               title: "Grow revenue",
               dueDate: "2025-12-31T00:00:00.000Z",
+              createdAt: "2025-06-01T00:00:00.000Z",
               keyResults: [
                 {
                   id: 1,
                   title: "Increase MRR",
                   metric: "MRR",
                   targetValue: "$100k",
+                  createdAt: "2025-08-01T00:00:00.000Z",
                   successCriteria: [
                     { id: 101, description: "MRR > $90k", threshold: "$90k" },
                   ],
                   reviews: [
-                    { id: 201, month: 7, year: 2025, progress: 80, notes: "Good progress" },
+                    { id: 201, month: 8, year: 2025, progress: 80, notes: "Good progress" },
                   ],
                 },
               ],
@@ -76,5 +78,16 @@ describe("OKRReviewPage - Review Modal", () => {
     // Save button should have correct color
     const saveBtn = screen.getByRole("button", { name: /Save/i });
     expect(saveBtn).toHaveStyle({ backgroundColor: "#1976d2" });
+  });
+
+  it("modal only allows valid months/years", async () => {
+    render(<OKRReviewPage />);
+    await waitFor(() => expect(screen.getByText(/KR 1: Increase MRR/)).toBeInTheDocument());
+    fireEvent.click(screen.getAllByRole("button", { name: "RateReviewIcon" })[0]);
+    await waitFor(() => expect(screen.getByText(/Review Key Result/)).toBeInTheDocument());
+    // Only August-December 2025 should be available
+    expect(screen.getByText("August")).toBeInTheDocument();
+    expect(screen.getByText("December")).toBeInTheDocument();
+    expect(screen.queryByText("July")).not.toBeInTheDocument();
   });
 });

--- a/src/app/objectives/review/__tests__/OKRReviewPageMonthRange.test.tsx
+++ b/src/app/objectives/review/__tests__/OKRReviewPageMonthRange.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import OKRReviewPage from "../page";
+
+describe("OKRReviewPage - Month/Year Range Logic", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            objectives: [
+              {
+                guid: "obj-1",
+                title: "Grow revenue",
+                dueDate: "2025-12-31T00:00:00.000Z",
+                createdAt: "2025-06-01T00:00:00.000Z",
+                keyResults: [
+                  {
+                    id: 1,
+                    title: "Increase MRR",
+                    metric: "MRR",
+                    targetValue: "$100k",
+                    createdAt: "2025-08-01T00:00:00.000Z",
+                    successCriteria: [],
+                    reviews: [],
+                  },
+                  {
+                    id: 2,
+                    title: "Reduce churn",
+                    metric: "Churn %",
+                    targetValue: "<5%",
+                    // No createdAt, should fallback to obj.createdAt
+                    successCriteria: [],
+                    reviews: [],
+                  },
+                ],
+              },
+            ],
+          }),
+      }) as any
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shows only months between KR createdAt and dueDate (inclusive)", async () => {
+    render(<OKRReviewPage />);
+    await waitFor(() => expect(screen.getByText(/KR 1: Increase MRR/)).toBeInTheDocument());
+    // Should show Aug 2025 to Dec 2025 for KR 1
+    expect(screen.getByText("Aug 2025")).toBeInTheDocument();
+    expect(screen.getByText("Dec 2025")).toBeInTheDocument();
+    expect(screen.queryByText("Jul 2025")).not.toBeInTheDocument();
+    // Should show Jun 2025 to Dec 2025 for KR 2 (fallback to obj.createdAt)
+    expect(screen.getByText("Jun 2025")).toBeInTheDocument();
+    expect(screen.getByText("Dec 2025")).toBeInTheDocument();
+  });
+
+  it("modal month/year pickers only allow valid range", async () => {
+    render(<OKRReviewPage />);
+    await waitFor(() => expect(screen.getByText(/KR 1: Increase MRR/)).toBeInTheDocument());
+    // Open modal for KR 1
+    fireEvent.click(screen.getAllByRole("button", { name: "RateReviewIcon" })[0]);
+    await waitFor(() => expect(screen.getByText(/Review Key Result/)).toBeInTheDocument());
+    // Only Aug-Dec 2025 should be available
+    expect(screen.getByText("August")).toBeInTheDocument();
+    expect(screen.getByText("December")).toBeInTheDocument();
+    expect(screen.queryByText("July")).not.toBeInTheDocument();
+    // Change to KR 2 (simulate by closing and opening modal for KR 2)
+    fireEvent.click(screen.getByText("Cancel"));
+    fireEvent.click(screen.getAllByRole("button", { name: "RateReviewIcon" })[1]);
+    await waitFor(() => expect(screen.getByText(/Review Key Result/)).toBeInTheDocument());
+    // Only Jun-Dec 2025 should be available
+    expect(screen.getByText("June")).toBeInTheDocument();
+    expect(screen.getByText("December")).toBeInTheDocument();
+    expect(screen.queryByText("May")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/objectives/review/page.tsx
+++ b/src/app/objectives/review/page.tsx
@@ -8,6 +8,7 @@ interface Objective {
   guid: string;
   title: string;
   dueDate: string;
+  createdAt?: string;
   keyResults: KeyResult[];
   completed?: boolean;
 }
@@ -16,6 +17,7 @@ interface KeyResult {
   title: string;
   metric: string;
   targetValue: string;
+  createdAt?: string;
   successCriteria?: SuccessCriterion[];
   reviews?: Review[];
 }
@@ -138,6 +140,26 @@ export default function OKRReviewPage() {
       .catch(() => setLoading(false));
   }
 
+  // Get month/year range between two dates
+  function getMonthYearRange(start: Date, end: Date) {
+    const result: { month: number; year: number }[] = [];
+    let current = new Date(start.getFullYear(), start.getMonth(), 1);
+    const last = new Date(end.getFullYear(), end.getMonth(), 1);
+    while (current <= last) {
+      result.push({ month: current.getMonth() + 1, year: current.getFullYear() });
+      current.setMonth(current.getMonth() + 1);
+    }
+    return result;
+  }
+
+  // Helper: get month/year range for modal (for selected KR)
+  function getModalMonthYearRange() {
+    if (!reviewModal.kr || !reviewModal.obj) return [];
+    const krCreated = reviewModal.kr.createdAt ? new Date(reviewModal.kr.createdAt) : (reviewModal.obj.createdAt ? new Date(reviewModal.obj.createdAt) : new Date());
+    const objDue = new Date(reviewModal.obj.dueDate);
+    return getMonthYearRange(krCreated, objDue);
+  }
+
   return (
     <Box display="flex">
       <SideNav open={sideNavOpen} onClose={() => setSideNavOpen(false)} />
@@ -161,45 +183,52 @@ export default function OKRReviewPage() {
                       <Typography variant="subtitle1" sx={{ color: 'black' }} mb={1}>Key Results</Typography>
                       {Array.isArray(obj.keyResults) && obj.keyResults.length > 0 ? (
                         <List sx={{ width: '100%' }}>
-                          {obj.keyResults.map((kr, krIdx) => (
-                            <ListItem key={kr.id} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'flex-start', mb: 1, width: '100%', border: '1.5px solid #888', borderRadius: 2, p: 1, background: '#fafafa' }}>
-                              <Box display="flex" alignItems="center" width="100%">
-                                <Typography sx={{ color: 'black', fontWeight: 500, flex: 1 }}>{`KR ${krIdx + 1}: ${kr.title}`}</Typography>
-                                <IconButton sx={{ color: 'black' }} onClick={() => openReviewModal(kr, obj)} size="small"><RateReviewIcon /></IconButton>
-                              </Box>
-                              <Typography sx={{ color: 'black', fontSize: 14, mb: 0.5 }}><strong>Metric:</strong> {kr.metric} | <strong>Target:</strong> {kr.targetValue}</Typography>
-                              {/* Review summary table */}
-                              <Box sx={{ width: '100%', mt: 1, mb: 1 }}>
-                                <Typography sx={{ fontWeight: 600, fontSize: 15, color: 'black', mb: 0.5 }}>Monthly Reviews:</Typography>
-                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                                  {months.map((m, i) => {
-                                    const review = kr.reviews?.find((r: any) => r.month === i + 1 && r.year === new Date().getFullYear());
-                                    return (
-                                      <Box key={m} sx={{ minWidth: 80, p: 1, border: '1px solid #ccc', borderRadius: 1, background: review ? '#e0ffe0' : '#f5f5f5', textAlign: 'center' }}>
-                                        <Typography sx={{ fontSize: 13, color: 'black' }}>{m.slice(0, 3)}</Typography>
-                                        <Typography sx={{ fontSize: 13, color: review ? 'green' : '#888' }}>{review ? `${review.progress}%` : '-'}</Typography>
-                                      </Box>
-                                    );
-                                  })}
+                          {obj.keyResults.map((kr, krIdx) => {
+                            // Determine start and end dates
+                            const krCreated = kr.createdAt ? new Date(kr.createdAt) : (obj.createdAt ? new Date(obj.createdAt) : new Date());
+                            const objDue = new Date(obj.dueDate);
+                            const monthYearRange = getMonthYearRange(krCreated, objDue);
+                            return (
+                              <ListItem key={kr.id} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'flex-start', mb: 1, width: '100%', border: '1.5px solid #888', borderRadius: 2, p: 1, background: '#fafafa' }}>
+                                <Box display="flex" alignItems="center" width="100%">
+                                  <Typography sx={{ color: 'black', fontWeight: 500, flex: 1 }}>{`KR ${krIdx + 1}: ${kr.title}`}</Typography>
+                                  <IconButton sx={{ color: 'black' }} onClick={() => openReviewModal(kr, obj)} size="small"><RateReviewIcon /></IconButton>
                                 </Box>
-                              </Box>
-                              <Typography sx={{ color: 'black', fontWeight: 600, mt: 1 }}>Success Criteria:</Typography>
-                              {Array.isArray(kr.successCriteria) && kr.successCriteria.length > 0 ? (
-                                <ul style={{ margin: 0, paddingLeft: 20, width: '100%' }}>
-                                  {kr.successCriteria.map((sc: any, scIdx: number) => (
-                                    <li key={sc.id} style={{ color: 'black', marginBottom: 4, fontSize: 14 }}>
-                                      <span>{sc.description}</span>
-                                      {sc.threshold && (
-                                        <span style={{ color: '#666', marginLeft: 8 }}>(Threshold: {sc.threshold})</span>
-                                      )}
-                                    </li>
-                                  ))}
-                                </ul>
-                              ) : (
-                                <Typography sx={{ color: '#888', margin: 0 }}>No success criteria.</Typography>
-                              )}
-                            </ListItem>
-                          ))}
+                                <Typography sx={{ color: 'black', fontSize: 14, mb: 0.5 }}><strong>Metric:</strong> {kr.metric} | <strong>Target:</strong> {kr.targetValue}</Typography>
+                                {/* Review summary table */}
+                                <Box sx={{ width: '100%', mt: 1, mb: 1 }}>
+                                  <Typography sx={{ fontWeight: 600, fontSize: 15, color: 'black', mb: 0.5 }}>Monthly Reviews:</Typography>
+                                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                    {monthYearRange.map(({ month, year }) => {
+                                      const review = kr.reviews?.find((r: any) => r.month === month && r.year === year);
+                                      const label = `${months[month - 1].slice(0, 3)} ${year}`;
+                                      return (
+                                        <Box key={label} sx={{ minWidth: 80, p: 1, border: '1px solid #ccc', borderRadius: 1, background: review ? '#e0ffe0' : '#f5f5f5', textAlign: 'center' }}>
+                                          <Typography sx={{ fontSize: 13, color: 'black' }}>{label}</Typography>
+                                          <Typography sx={{ fontSize: 13, color: review ? 'green' : '#888' }}>{review ? `${review.progress}%` : '-'}</Typography>
+                                        </Box>
+                                      );
+                                    })}
+                                  </Box>
+                                </Box>
+                                <Typography sx={{ color: 'black', fontWeight: 600, mt: 1 }}>Success Criteria:</Typography>
+                                {Array.isArray(kr.successCriteria) && kr.successCriteria.length > 0 ? (
+                                  <ul style={{ margin: 0, paddingLeft: 20, width: '100%' }}>
+                                    {kr.successCriteria.map((sc: any, scIdx: number) => (
+                                      <li key={sc.id} style={{ color: 'black', marginBottom: 4, fontSize: 14 }}>
+                                        <span>{sc.description}</span>
+                                        {sc.threshold && (
+                                          <span style={{ color: '#666', marginLeft: 8 }}>(Threshold: {sc.threshold})</span>
+                                        )}
+                                      </li>
+                                    ))}
+                                  </ul>
+                                ) : (
+                                  <Typography sx={{ color: '#888', margin: 0 }}>No success criteria.</Typography>
+                                )}
+                              </ListItem>
+                            );
+                          })}
                         </List>
                       ) : (
                         <Typography sx={{ color: '#888', margin: 0 }}>No key results.</Typography>
@@ -225,21 +254,26 @@ export default function OKRReviewPage() {
                 sx={{ color: 'black' }}
                 inputProps={{ style: { color: 'black' } }}
               >
-                {months.map((m, i) => (
-                  <MenuItem key={m} value={i + 1} sx={{ color: 'black' }}>{m}</MenuItem>
+                {getModalMonthYearRange().filter((v, i, arr) => arr.findIndex(x => x.month === v.month && x.year === v.year) === i && v.year === selectedYear).map(({ month }) => (
+                  <MenuItem key={month} value={month} sx={{ color: 'black' }}>{months[month - 1]}</MenuItem>
                 ))}
               </Select>
             </FormControl>
-            <TextField
-              label="Year"
-              type="number"
-              value={selectedYear}
-              onChange={e => handleMonthYearChange(selectedMonth, Number(e.target.value))}
-              fullWidth
-              sx={{ mb: 2, color: 'black' }}
-              InputLabelProps={{ style: { color: 'black' } }}
-              InputProps={{ style: { color: 'black' } }}
-            />
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <InputLabel id="year-label" sx={{ color: 'black' }}>Year</InputLabel>
+              <Select
+                labelId="year-label"
+                value={selectedYear}
+                label="Year"
+                onChange={e => handleMonthYearChange(selectedMonth, Number(e.target.value))}
+                sx={{ color: 'black' }}
+                inputProps={{ style: { color: 'black' } }}
+              >
+                {[...new Set(getModalMonthYearRange().map(({ year }) => year))].map(year => (
+                  <MenuItem key={year} value={year} sx={{ color: 'black' }}>{year}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
             <Typography gutterBottom sx={{ color: 'black' }}>Progress: {reviewProgress}%</Typography>
             <Slider
               value={reviewProgress}


### PR DESCRIPTION
- Add createdAt to KeyResult model and API responses
- Show monthly review boxes only for months between KR creation and objective due date (inclusive)
- Update review modal month/year pickers to only allow valid range for each KR
- Update and add tests to verify correct month/year logic in UI and modal
- Improve UX by preventing reviews outside valid KR period