### PR TITLE
feat: implement secure quarterly OKR review API with user ownership c…

### DIFF
--- a/prisma/migrations/20250801140831_add_objective_quarterly_review/migration.sql
+++ b/prisma/migrations/20250801140831_add_objective_quarterly_review/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "public"."ObjectiveQuarterlyReview" (
+    "id" SERIAL NOT NULL,
+    "objectiveId" INTEGER NOT NULL,
+    "quarter" INTEGER NOT NULL,
+    "year" INTEGER NOT NULL,
+    "grading" DOUBLE PRECISION,
+    "lessonsLearned" TEXT,
+    "strategicAdjustment" TEXT,
+    "nextQuarterPlanning" TEXT,
+    "engagement" TEXT,
+    "actionCompletion" TEXT,
+    "strategicAlignment" TEXT,
+    "feedbackQuality" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ObjectiveQuarterlyReview_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ObjectiveQuarterlyReview_objectiveId_quarter_year_key" ON "public"."ObjectiveQuarterlyReview"("objectiveId", "quarter", "year");
+
+-- AddForeignKey
+ALTER TABLE "public"."ObjectiveQuarterlyReview" ADD CONSTRAINT "ObjectiveQuarterlyReview_objectiveId_fkey" FOREIGN KEY ("objectiveId") REFERENCES "public"."Objective"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Objective {
   user        User          @relation(fields: [userId], references: [id])
   userId      Int
   keyResults  KeyResult[]
+  quarterlyReviews ObjectiveQuarterlyReview[]
 }
 
 model KeyResult {
@@ -81,4 +82,24 @@ model KeyResultReview {
   updatedAt    DateTime @updatedAt
 
   @@unique([keyResultId, month, year])
+}
+
+model ObjectiveQuarterlyReview {
+  id                Int      @id @default(autoincrement())
+  objective         Objective @relation(fields: [objectiveId], references: [id])
+  objectiveId       Int
+  quarter           Int      // 1-4
+  year              Int
+  grading           Float?   // 0.0-1.0, calculated from monthly reviews but editable
+  lessonsLearned    String?
+  strategicAdjustment String?
+  nextQuarterPlanning String?
+  engagement        String?
+  actionCompletion  String?
+  strategicAlignment String?
+  feedbackQuality   String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  @@unique([objectiveId, quarter, year])
 }

--- a/src/app/api/objectives/[guid]/quarterly-reviews/[id]/route.ts
+++ b/src/app/api/objectives/[guid]/quarterly-reviews/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/auth/authOptions";
+
+// GET: Get a single quarterly review
+export async function GET(req: NextRequest, context: any) {
+  const params = await context.params;
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = params;
+  const review = await prisma.objectiveQuarterlyReview.findUnique({ where: { id: Number(id) }, include: { objective: true } });
+  if (!review) return NextResponse.json({ error: 'Quarterly review not found' }, { status: 404 });
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user || review.objective.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return NextResponse.json({ review });
+}
+
+// PUT: Update a quarterly review
+export async function PUT(req: NextRequest, context: any) {
+  const params = await context.params;
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = params;
+  const review = await prisma.objectiveQuarterlyReview.findUnique({ where: { id: Number(id) }, include: { objective: true } });
+  if (!review) return NextResponse.json({ error: 'Quarterly review not found' }, { status: 404 });
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user || review.objective.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json();
+  const updated = await prisma.objectiveQuarterlyReview.update({
+    where: { id: Number(id) },
+    data: body,
+  });
+  return NextResponse.json({ review: updated });
+}
+
+// DELETE: Delete a quarterly review
+export async function DELETE(req: NextRequest, context: any) {
+  const params = await context.params;
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = params;
+  const review = await prisma.objectiveQuarterlyReview.findUnique({ where: { id: Number(id) }, include: { objective: true } });
+  if (!review) return NextResponse.json({ error: 'Quarterly review not found' }, { status: 404 });
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user || review.objective.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  await prisma.objectiveQuarterlyReview.delete({ where: { id: Number(id) } });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/objectives/[guid]/quarterly-reviews/route.ts
+++ b/src/app/api/objectives/[guid]/quarterly-reviews/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/auth/authOptions";
+
+// GET: List all quarterly reviews for an objective
+export async function GET(req: NextRequest, context: any) {
+  const params = await context.params;
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { guid } = params;
+  const objective = await prisma.objective.findUnique({
+    where: { guid },
+    include: { quarterlyReviews: true, user: true },
+  });
+  if (!objective) return NextResponse.json({ error: 'Objective not found' }, { status: 404 });
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user || objective.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return NextResponse.json({ quarterlyReviews: objective.quarterlyReviews });
+}
+
+// POST: Create or upsert a quarterly review for an objective
+export async function POST(req: NextRequest, context: any) {
+  const params = await context.params;
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { guid } = params;
+  const body = await req.json();
+  const { quarter, year, grading, lessonsLearned, strategicAdjustment, nextQuarterPlanning, engagement, actionCompletion, strategicAlignment, feedbackQuality } = body;
+  const objective = await prisma.objective.findUnique({ where: { guid } });
+  if (!objective) return NextResponse.json({ error: 'Objective not found' }, { status: 404 });
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user || objective.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const review = await prisma.objectiveQuarterlyReview.upsert({
+    where: { objectiveId_quarter_year: { objectiveId: objective.id, quarter, year } },
+    update: { grading, lessonsLearned, strategicAdjustment, nextQuarterPlanning, engagement, actionCompletion, strategicAlignment, feedbackQuality },
+    create: { objectiveId: objective.id, quarter, year, grading, lessonsLearned, strategicAdjustment, nextQuarterPlanning, engagement, actionCompletion, strategicAlignment, feedbackQuality },
+  });
+  return NextResponse.json({ review });
+}

--- a/src/app/api/objectives/user/route.ts
+++ b/src/app/api/objectives/user/route.ts
@@ -49,6 +49,21 @@ export async function GET(req: Request) {
           },
         },
       },
+      quarterlyReviews: {
+        select: {
+          id: true,
+          quarter: true,
+          year: true,
+          grading: true,
+          lessonsLearned: true,
+          strategicAdjustment: true,
+          nextQuarterPlanning: true,
+          engagement: true,
+          actionCompletion: true,
+          strategicAlignment: true,
+          feedbackQuality: true,
+        },
+      },
     },
   });
   return NextResponse.json({ objectives });

--- a/src/app/objectives/review/__tests__/OKRReviewPageQuarterlyModal.test.tsx
+++ b/src/app/objectives/review/__tests__/OKRReviewPageQuarterlyModal.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import OKRReviewPage from "../page";
+
+describe("OKRReviewPage - Quarterly Review Modal", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            objectives: [
+              {
+                guid: "obj-1",
+                title: "Grow revenue",
+                dueDate: "2025-12-31T00:00:00.000Z",
+                createdAt: "2025-06-01T00:00:00.000Z",
+                quarterlyReviews: [
+                  { id: 1, quarter: 3, year: 2025, grading: 0.8, lessonsLearned: 'LL', strategicAdjustment: 'SA', nextQuarterPlanning: 'NQP', engagement: 'E', actionCompletion: 'AC', strategicAlignment: 'SAL', feedbackQuality: 'FQ' },
+                ],
+                keyResults: [],
+              },
+            ],
+          }),
+      }) as any
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("opens quarterly modal, displays review fields, and allows editing", async () => {
+    render(<OKRReviewPage />);
+    await waitFor(() => expect(screen.getByText(/Q3 2025/)).toBeInTheDocument());
+    // Open modal
+    fireEvent.click(screen.getByText("Q3 2025"));
+    expect(screen.getByText(/Quarterly Review/)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("0.8")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("LL")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("SA")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("NQP")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("E")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("AC")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("SAL")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("FQ")).toBeInTheDocument();
+    // Change grading
+    fireEvent.change(screen.getByLabelText(/Lessons Learned/), { target: { value: "Updated LL" } });
+    // Save
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+    await waitFor(() => expect(screen.queryByText(/Quarterly Review/)).not.toBeInTheDocument());
+  });
+});

--- a/src/app/objectives/review/__tests__/OKRReviewPageQuarterlyRange.test.tsx
+++ b/src/app/objectives/review/__tests__/OKRReviewPageQuarterlyRange.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import OKRReviewPage from "../page";
+
+describe("OKRReviewPage - Quarterly Review Range Logic", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            objectives: [
+              {
+                guid: "obj-1",
+                title: "Grow revenue",
+                dueDate: "2025-12-31T00:00:00.000Z",
+                createdAt: "2025-06-01T00:00:00.000Z",
+                quarterlyReviews: [
+                  { id: 1, quarter: 3, year: 2025, grading: 0.8, lessonsLearned: '', strategicAdjustment: '', nextQuarterPlanning: '', engagement: '', actionCompletion: '', strategicAlignment: '', feedbackQuality: '' },
+                ],
+                keyResults: [],
+              },
+              {
+                guid: "obj-2",
+                title: "Expand market",
+                dueDate: "2026-03-31T00:00:00.000Z",
+                createdAt: "2025-11-15T00:00:00.000Z",
+                quarterlyReviews: [],
+                keyResults: [],
+              },
+            ],
+          }),
+      }) as any
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shows only quarters between createdAt and dueDate (inclusive) with correct year/quarter labels", async () => {
+    render(<OKRReviewPage />);
+    await waitFor(() => expect(screen.getByText(/Objective 1: Grow revenue/)).toBeInTheDocument());
+    // For obj-1: createdAt Jun 2025, dueDate Dec 2025 => Q2, Q3, Q4 2025
+    expect(screen.getByText("Q2 2025")).toBeInTheDocument();
+    expect(screen.getByText("Q3 2025")).toBeInTheDocument();
+    expect(screen.getByText("Q4 2025")).toBeInTheDocument();
+    expect(screen.queryByText("Q1 2025")).not.toBeInTheDocument();
+    expect(screen.queryByText("Q1 2026")).not.toBeInTheDocument();
+    // For obj-2: createdAt Nov 2025, dueDate Mar 2026 => Q4 2025, Q1 2026
+    expect(screen.getByText("Q4 2025")).toBeInTheDocument();
+    expect(screen.getByText("Q1 2026")).toBeInTheDocument();
+    expect(screen.queryByText("Q3 2025")).not.toBeInTheDocument();
+    expect(screen.queryByText("Q2 2026")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/objectives/review/page.tsx
+++ b/src/app/objectives/review/page.tsx
@@ -4,14 +4,20 @@ import SideNav from "@/components/SideNav";
 import { Box, Typography, List, ListItem, ListItemText, Button, Modal, Slider, TextField, IconButton, MenuItem, Select, InputLabel, FormControl } from "@mui/material";
 import RateReviewIcon from "@mui/icons-material/RateReview";
 
-interface Objective {
-  guid: string;
-  title: string;
-  dueDate: string;
-  createdAt?: string;
-  keyResults: KeyResult[];
-  completed?: boolean;
+interface SuccessCriterion {
+  id: number;
+  description: string;
+  threshold?: string;
 }
+
+interface Review {
+  id: number;
+  month: number;
+  year: number;
+  progress: number;
+  notes: string;
+}
+
 interface KeyResult {
   id: number;
   title: string;
@@ -21,17 +27,29 @@ interface KeyResult {
   successCriteria?: SuccessCriterion[];
   reviews?: Review[];
 }
-interface SuccessCriterion {
+
+interface QuarterlyReview {
   id: number;
-  description: string;
-  threshold?: string;
-}
-interface Review {
-  id: number;
-  month: number;
+  quarter: number;
   year: number;
-  progress: number;
-  notes: string;
+  grading: number;
+  lessonsLearned: string;
+  strategicAdjustment: string;
+  nextQuarterPlanning: string;
+  engagement: string;
+  actionCompletion: string;
+  strategicAlignment: string;
+  feedbackQuality: string;
+}
+
+interface Objective {
+  guid: string;
+  title: string;
+  dueDate: string;
+  createdAt?: string;
+  keyResults: KeyResult[];
+  completed?: boolean;
+  quarterlyReviews?: QuarterlyReview[];
 }
 
 export default function OKRReviewPage() {
@@ -45,6 +63,19 @@ export default function OKRReviewPage() {
   const [reviewNotes, setReviewNotes] = useState<string>("");
   const [reviewId, setReviewId] = useState<number | null>(null);
   const [modalLoading, setModalLoading] = useState(false);
+  const [quarterlyModal, setQuarterlyModal] = useState<{ open: boolean, obj?: any, review?: any, quarter?: number, year?: number }>({ open: false });
+  const [quarterlyFields, setQuarterlyFields] = useState({
+    grading: 0,
+    lessonsLearned: '',
+    strategicAdjustment: '',
+    nextQuarterPlanning: '',
+    engagement: '',
+    actionCompletion: '',
+    strategicAlignment: '',
+    feedbackQuality: '',
+  });
+  const [quarterlyReviewId, setQuarterlyReviewId] = useState<number | null>(null);
+  const [quarterlyModalLoading, setQuarterlyModalLoading] = useState(false);
   const months = [
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
@@ -66,12 +97,14 @@ export default function OKRReviewPage() {
     return kr.reviews?.find((r: any) => r.month === month && r.year === year);
   }
 
-  // Open modal for KR
-  function openReviewModal(kr: any, obj: any) {
+  // Open modal for KR (optionally for a specific month/year)
+  function openReviewModal(kr: any, obj: any, month?: number, year?: number) {
     setReviewModal({ open: true, kr, obj });
-    setSelectedMonth(new Date().getMonth() + 1);
-    setSelectedYear(new Date().getFullYear());
-    const review = getReviewForMonth(kr, new Date().getMonth() + 1, new Date().getFullYear());
+    const selMonth = month ?? (new Date().getMonth() + 1);
+    const selYear = year ?? (new Date().getFullYear());
+    setSelectedMonth(selMonth);
+    setSelectedYear(selYear);
+    const review = getReviewForMonth(kr, selMonth, selYear);
     setReviewProgress(review?.progress ?? 0);
     setReviewNotes(review?.notes ?? "");
     setReviewId(review?.id ?? null);
@@ -160,6 +193,90 @@ export default function OKRReviewPage() {
     return getMonthYearRange(krCreated, objDue);
   }
 
+  // Helper: get quarterly review for quarter/year
+  function getQuarterlyReview(obj: any, quarter: number, year: number) {
+    return obj.quarterlyReviews?.find((r: any) => r.quarter === quarter && r.year === year);
+  }
+
+  // Open quarterly review modal
+  function openQuarterlyModal(obj: any, quarter: number, year: number) {
+    const review = getQuarterlyReview(obj, quarter, year);
+    setQuarterlyModal({ open: true, obj, review, quarter, year });
+    setQuarterlyFields({
+      grading: review?.grading ?? 0,
+      lessonsLearned: review?.lessonsLearned ?? '',
+      strategicAdjustment: review?.strategicAdjustment ?? '',
+      nextQuarterPlanning: review?.nextQuarterPlanning ?? '',
+      engagement: review?.engagement ?? '',
+      actionCompletion: review?.actionCompletion ?? '',
+      strategicAlignment: review?.strategicAlignment ?? '',
+      feedbackQuality: review?.feedbackQuality ?? '',
+    });
+    setQuarterlyReviewId(review?.id ?? null);
+  }
+
+  // Save quarterly review
+  async function handleSaveQuarterlyReview() {
+    if (!quarterlyModal.obj || !quarterlyModal.quarter || !quarterlyModal.year) return;
+    setQuarterlyModalLoading(true);
+    await fetch(`/api/objectives/${quarterlyModal.obj.guid}/quarterly-reviews`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        quarter: quarterlyModal.quarter,
+        year: quarterlyModal.year,
+        ...quarterlyFields,
+      }),
+    });
+    setQuarterlyModalLoading(false);
+    setQuarterlyModal({ open: false });
+    setLoading(true);
+    fetch('/api/objectives/user')
+      .then(res => res.json())
+      .then(data => {
+        setObjectives(Array.isArray(data?.objectives) ? data.objectives : []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }
+
+  // Delete quarterly review
+  async function handleDeleteQuarterlyReview() {
+    if (!quarterlyReviewId || !quarterlyModal.obj) return;
+    setQuarterlyModalLoading(true);
+    await fetch(`/api/objectives/${quarterlyModal.obj.guid}/quarterly-reviews/${quarterlyReviewId}`, {
+      method: 'DELETE',
+    });
+    setQuarterlyModalLoading(false);
+    setQuarterlyModal({ open: false });
+    setLoading(true);
+    fetch('/api/objectives/user')
+      .then(res => res.json())
+      .then(data => {
+        setObjectives(Array.isArray(data?.objectives) ? data.objectives : []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }
+
+  // Helper: get all quarters between two dates (inclusive)
+  function getQuarterRange(start: Date, end: Date) {
+    const result: { quarter: number; year: number }[] = [];
+    let current = new Date(start.getFullYear(), start.getMonth(), 1);
+    const last = new Date(end.getFullYear(), end.getMonth(), 1);
+    while (current <= last) {
+      const year = current.getFullYear();
+      const quarter = Math.floor(current.getMonth() / 3) + 1;
+      // Only add if not already present (avoid duplicate quarters in same year)
+      if (!result.some(q => q.quarter === quarter && q.year === year)) {
+        result.push({ quarter, year });
+      }
+      // Move to next quarter
+      current.setMonth(current.getMonth() + 3 - (current.getMonth() % 3));
+    }
+    return result;
+  }
+
   return (
     <Box display="flex">
       <SideNav open={sideNavOpen} onClose={() => setSideNavOpen(false)} />
@@ -176,65 +293,143 @@ export default function OKRReviewPage() {
                 <Typography>No objectives found.</Typography>
               ) : (
                 <List>
-                  {objectives.map((obj, idx) => (
-                    <ListItem key={obj.guid} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'flex-start', mb: 2, width: '100%', border: '2px solid black', borderRadius: 2, p: 2 }}>
-                      <Typography variant="h6" sx={{ color: 'black', fontWeight: 600 }}>{`Objective ${idx + 1}: ${obj.title}`}</Typography>
-                      <Typography sx={{ color: 'black', mb: 1 }}><strong>Due Date:</strong> {obj.dueDate ? new Date(obj.dueDate).toLocaleDateString('en-GB') : '-'}</Typography>
-                      <Typography variant="subtitle1" sx={{ color: 'black' }} mb={1}>Key Results</Typography>
-                      {Array.isArray(obj.keyResults) && obj.keyResults.length > 0 ? (
-                        <List sx={{ width: '100%' }}>
-                          {obj.keyResults.map((kr, krIdx) => {
-                            // Determine start and end dates
-                            const krCreated = kr.createdAt ? new Date(kr.createdAt) : (obj.createdAt ? new Date(obj.createdAt) : new Date());
-                            const objDue = new Date(obj.dueDate);
-                            const monthYearRange = getMonthYearRange(krCreated, objDue);
-                            return (
-                              <ListItem key={kr.id} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'flex-start', mb: 1, width: '100%', border: '1.5px solid #888', borderRadius: 2, p: 1, background: '#fafafa' }}>
-                                <Box display="flex" alignItems="center" width="100%">
-                                  <Typography sx={{ color: 'black', fontWeight: 500, flex: 1 }}>{`KR ${krIdx + 1}: ${kr.title}`}</Typography>
-                                  <IconButton sx={{ color: 'black' }} onClick={() => openReviewModal(kr, obj)} size="small"><RateReviewIcon /></IconButton>
+                  {objectives.map((obj, idx) => {
+                    // Determine quarter range for the objective
+                    const objCreated = obj.createdAt ? new Date(obj.createdAt) : new Date();
+                    const objDue = new Date(obj.dueDate);
+                    const quarterRange = getQuarterRange(objCreated, objDue);
+                    return (
+                      <ListItem key={obj.guid} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'flex-start', mb: 2, width: '100%', border: '2px solid black', borderRadius: 2, p: 2 }}>
+                        <Typography variant="h6" sx={{ color: 'black', fontWeight: 600 }}>{`Objective ${idx + 1}: ${obj.title}`}</Typography>
+                        <Typography sx={{ color: 'black', mb: 1 }}><strong>Due Date:</strong> {obj.dueDate ? new Date(obj.dueDate).toLocaleDateString('en-GB') : '-'}</Typography>
+                        {/* Quarterly Reviews Row (dynamic) */}
+                        <Box sx={{ width: '100%', mt: 1, mb: 2 }}>
+                          <Typography sx={{ fontWeight: 600, fontSize: 15, color: 'black', mb: 0.5 }}>Quarterly Reviews:</Typography>
+                          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                            {quarterRange.map(({ quarter, year }) => {
+                              const review = obj.quarterlyReviews?.find((r) => r.quarter === quarter && r.year === year);
+                              const now = new Date();
+                              const currentQuarter = Math.floor(now.getMonth() / 3) + 1;
+                              const currentYear = now.getFullYear();
+                              let bgColor = '#f5f5f5'; // default grey
+                              if (review) {
+                                bgColor = '#e0ffe0'; // green
+                              } else if (year < currentYear || (year === currentYear && quarter < currentQuarter)) {
+                                bgColor = '#ffe0e0'; // red
+                              } else if (year === currentYear && quarter === currentQuarter) {
+                                bgColor = '#fff8e1'; // amber
+                              }
+                              return (
+                                <Box
+                                  key={`Q${quarter}-${year}`}
+                                  sx={{ minWidth: 90, p: 1, border: '1px solid #ccc', borderRadius: 1, background: bgColor, textAlign: 'center', cursor: 'pointer', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 3, background: '#e3f2fd' } }}
+                                  onClick={() => openQuarterlyModal(obj, quarter, year)}
+                                  aria-label={`Edit or create quarterly review for Q${quarter} ${year}`}
+                                  role="button"
+                                  tabIndex={0}
+                                  onKeyDown={e => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      openQuarterlyModal(obj, quarter, year);
+                                    }
+                                  }}
+                                >
+                                  <Typography sx={{ fontSize: 13, color: 'black' }}>{`Q${quarter} ${year}`}</Typography>
+                                  <Typography sx={{ fontSize: 13, color: review ? 'green' : (bgColor === '#ffe0e0' ? 'red' : (bgColor === '#fff8e1' ? '#ff9800' : '#888')) }}>{review ? `${Math.round((review.grading ?? 0) * 100) / 100}` : '-'}</Typography>
                                 </Box>
-                                <Typography sx={{ color: 'black', fontSize: 14, mb: 0.5 }}><strong>Metric:</strong> {kr.metric} | <strong>Target:</strong> {kr.targetValue}</Typography>
-                                {/* Review summary table */}
-                                <Box sx={{ width: '100%', mt: 1, mb: 1 }}>
-                                  <Typography sx={{ fontWeight: 600, fontSize: 15, color: 'black', mb: 0.5 }}>Monthly Reviews:</Typography>
-                                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                                    {monthYearRange.map(({ month, year }) => {
-                                      const review = kr.reviews?.find((r: any) => r.month === month && r.year === year);
-                                      const label = `${months[month - 1].slice(0, 3)} ${year}`;
-                                      return (
-                                        <Box key={label} sx={{ minWidth: 80, p: 1, border: '1px solid #ccc', borderRadius: 1, background: review ? '#e0ffe0' : '#f5f5f5', textAlign: 'center' }}>
-                                          <Typography sx={{ fontSize: 13, color: 'black' }}>{label}</Typography>
-                                          <Typography sx={{ fontSize: 13, color: review ? 'green' : '#888' }}>{review ? `${review.progress}%` : '-'}</Typography>
-                                        </Box>
-                                      );
-                                    })}
+                              );
+                            })}
+                          </Box>
+                        </Box>
+                        <Typography variant="subtitle1" sx={{ color: 'black' }} mb={1}>Key Results</Typography>
+                        {Array.isArray(obj.keyResults) && obj.keyResults.length > 0 ? (
+                          <List sx={{ width: '100%' }}>
+                            {obj.keyResults.map((kr, krIdx) => {
+                              // Determine start and end dates
+                              const krCreated = kr.createdAt ? new Date(kr.createdAt) : (obj.createdAt ? new Date(obj.createdAt) : new Date());
+                              const objDue = new Date(obj.dueDate);
+                              const monthYearRange = getMonthYearRange(krCreated, objDue);
+                              return (
+                                <ListItem key={kr.id} alignItems="flex-start" sx={{ flexDirection: 'column', alignItems: 'flex-start', mb: 1, width: '100%', border: '1.5px solid #888', borderRadius: 2, p: 1, background: '#fafafa' }}>
+                                  <Box display="flex" alignItems="center" width="100%">
+                                    <Typography sx={{ color: 'black', fontWeight: 500, flex: 1 }}>{`KR ${krIdx + 1}: ${kr.title}`}</Typography>
+                                    <Button
+                                      onClick={() => openReviewModal(kr, obj)}
+                                      size="small"
+                                      sx={{ color: 'black', display: 'flex', alignItems: 'center', textTransform: 'none', minWidth: 0, ml: 1 }}
+                                      aria-label="Create monthly review"
+                                    >
+                                      <RateReviewIcon sx={{ mr: 1 }} />
+                                      <span style={{ fontSize: 14 }}>Create monthly review</span>
+                                    </Button>
                                   </Box>
-                                </Box>
-                                <Typography sx={{ color: 'black', fontWeight: 600, mt: 1 }}>Success Criteria:</Typography>
-                                {Array.isArray(kr.successCriteria) && kr.successCriteria.length > 0 ? (
-                                  <ul style={{ margin: 0, paddingLeft: 20, width: '100%' }}>
-                                    {kr.successCriteria.map((sc: any, scIdx: number) => (
-                                      <li key={sc.id} style={{ color: 'black', marginBottom: 4, fontSize: 14 }}>
-                                        <span>{sc.description}</span>
-                                        {sc.threshold && (
-                                          <span style={{ color: '#666', marginLeft: 8 }}>(Threshold: {sc.threshold})</span>
-                                        )}
-                                      </li>
-                                    ))}
-                                  </ul>
-                                ) : (
-                                  <Typography sx={{ color: '#888', margin: 0 }}>No success criteria.</Typography>
-                                )}
-                              </ListItem>
-                            );
-                          })}
-                        </List>
-                      ) : (
-                        <Typography sx={{ color: '#888', margin: 0 }}>No key results.</Typography>
-                      )}
-                    </ListItem>
-                  ))}
+                                  <Typography sx={{ color: 'black', fontSize: 14, mb: 0.5 }}><strong>Metric:</strong> {kr.metric} | <strong>Target:</strong> {kr.targetValue}</Typography>
+                                  {/* Review summary table */}
+                                  <Box sx={{ width: '100%', mt: 1, mb: 1 }}>
+                                    <Typography sx={{ fontWeight: 600, fontSize: 15, color: 'black', mb: 0.5 }}>Monthly Reviews:</Typography>
+                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                      {monthYearRange.map(({ month, year }) => {
+                                        const review = kr.reviews?.find((r: any) => r.month === month && r.year === year);
+                                        const label = `${months[month - 1].slice(0, 3)} ${year}`;
+                                        // Color logic
+                                        const now = new Date();
+                                        const currentMonth = now.getMonth() + 1;
+                                        const currentYear = now.getFullYear();
+                                        let bgColor = '#f5f5f5'; // default grey
+                                        if (review) {
+                                          bgColor = '#e0ffe0'; // green
+                                        } else if (year < currentYear || (year === currentYear && month < currentMonth)) {
+                                          bgColor = '#ffe0e0'; // red
+                                        } else if (year === currentYear && month === currentMonth) {
+                                          bgColor = '#fff8e1'; // amber
+                                        }
+                                        return (
+                                          <Box
+                                            key={label}
+                                            sx={{ minWidth: 80, p: 1, border: '1px solid #ccc', borderRadius: 1, background: bgColor, textAlign: 'center', cursor: 'pointer', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 3, background: '#e3f2fd' } }}
+                                            onClick={() => {
+                                              openReviewModal(kr, obj, month, year);
+                                            }}
+                                            aria-label={`Edit or create review for ${label}`}
+                                            role="button"
+                                            tabIndex={0}
+                                            onKeyDown={e => {
+                                              if (e.key === 'Enter' || e.key === ' ') {
+                                                openReviewModal(kr, obj, month, year);
+                                              }
+                                            }}
+                                          >
+                                            <Typography sx={{ fontSize: 13, color: 'black' }}>{label}</Typography>
+                                            <Typography sx={{ fontSize: 13, color: review ? 'green' : (bgColor === '#ffe0e0' ? 'red' : (bgColor === '#fff8e1' ? '#ff9800' : '#888')) }}>{review ? `${review.progress}%` : '-'}</Typography>
+                                          </Box>
+                                        );
+                                      })}
+                                    </Box>
+                                  </Box>
+                                  <Typography sx={{ color: 'black', fontWeight: 600, mt: 1 }}>Success Criteria:</Typography>
+                                  {Array.isArray(kr.successCriteria) && kr.successCriteria.length > 0 ? (
+                                    <ul style={{ margin: 0, paddingLeft: 20, width: '100%' }}>
+                                      {kr.successCriteria.map((sc: any, scIdx: number) => (
+                                        <li key={sc.id} style={{ color: 'black', marginBottom: 4, fontSize: 14 }}>
+                                          <span>{sc.description}</span>
+                                          {sc.threshold && (
+                                            <span style={{ color: '#666', marginLeft: 8 }}>(Threshold: {sc.threshold})</span>
+                                          )}
+                                        </li>
+                                      ))}
+                                    </ul>
+                                  ) : (
+                                    <Typography sx={{ color: '#888', margin: 0 }}>No success criteria.</Typography>
+                                  )}
+                                </ListItem>
+                              );
+                            })}
+                          </List>
+                        ) : (
+                          <Typography sx={{ color: '#888', margin: 0 }}>No key results.</Typography>
+                        )}
+                      </ListItem>
+                    );
+                  })}
                 </List>
               )
             )}
@@ -305,6 +500,131 @@ export default function OKRReviewPage() {
                 </Button>
               )}
               <Button variant="contained" color="primary" onClick={handleSaveReview} disabled={modalLoading} sx={{ color: '#fff', backgroundColor: '#1976d2', '&:hover': { backgroundColor: '#1565c0' } }}>
+                Save
+              </Button>
+            </Box>
+          </Box>
+        </Modal>
+        {/* Quarterly Review Modal */}
+        <Modal open={quarterlyModal.open} onClose={() => setQuarterlyModal({ open: false })}>
+          <Box sx={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: { xs: '95vw', sm: 600, md: 650 },
+            maxWidth: '98vw',
+            maxHeight: '90vh',
+            bgcolor: 'background.paper',
+            boxShadow: 24,
+            p: 4,
+            borderRadius: 2,
+            color: 'black',
+            overflowY: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+          }}>
+            <Typography variant="h6" mb={2} sx={{ color: 'black' }}>Quarterly Review</Typography>
+            <Typography sx={{ mb: 2, color: 'black' }}>
+              Quarter: <b>{quarterlyModal.quarter}</b> &nbsp; Year: <b>{quarterlyModal.year}</b>
+            </Typography>
+            <Typography gutterBottom sx={{ color: 'black' }}>OKR Grading (0.0 - 1.0): {quarterlyFields.grading}</Typography>
+            <Slider
+              value={quarterlyFields.grading}
+              onChange={(_, v) => setQuarterlyFields(f => ({ ...f, grading: typeof v === 'number' ? v : 0 }))}
+              min={0}
+              max={1}
+              step={0.01}
+              valueLabelDisplay="auto"
+              sx={{ mb: 2, color: 'black' }}
+            />
+            <TextField
+              label="Lessons Learned"
+              value={quarterlyFields.lessonsLearned}
+              onChange={e => setQuarterlyFields(f => ({ ...f, lessonsLearned: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={2}
+              sx={{ mb: 2, color: 'black' }}
+              InputLabelProps={{ style: { color: 'black' } }}
+              InputProps={{ style: { color: 'black' } }}
+            />
+            <TextField
+              label="Strategic Adjustment"
+              value={quarterlyFields.strategicAdjustment}
+              onChange={e => setQuarterlyFields(f => ({ ...f, strategicAdjustment: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={2}
+              sx={{ mb: 2, color: 'black' }}
+              InputLabelProps={{ style: { color: 'black' } }}
+              InputProps={{ style: { color: 'black' } }}
+            />
+            <TextField
+              label="Next Quarter Planning"
+              value={quarterlyFields.nextQuarterPlanning}
+              onChange={e => setQuarterlyFields(f => ({ ...f, nextQuarterPlanning: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={2}
+              sx={{ mb: 2, color: 'black' }}
+              InputLabelProps={{ style: { color: 'black' } }}
+              InputProps={{ style: { color: 'black' } }}
+            />
+            <TextField
+              label="Engagement Levels"
+              value={quarterlyFields.engagement}
+              onChange={e => setQuarterlyFields(f => ({ ...f, engagement: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={2}
+              sx={{ mb: 2, color: 'black' }}
+              InputLabelProps={{ style: { color: 'black' } }}
+              InputProps={{ style: { color: 'black' } }}
+            />
+            <TextField
+              label="Action Item Completion"
+              value={quarterlyFields.actionCompletion}
+              onChange={e => setQuarterlyFields(f => ({ ...f, actionCompletion: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={2}
+              sx={{ mb: 2, color: 'black' }}
+              InputLabelProps={{ style: { color: 'black' } }}
+              InputProps={{ style: { color: 'black' } }}
+            />
+            <TextField
+              label="Strategic Alignment"
+              value={quarterlyFields.strategicAlignment}
+              onChange={e => setQuarterlyFields(f => ({ ...f, strategicAlignment: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={2}
+              sx={{ mb: 2, color: 'black' }}
+              InputLabelProps={{ style: { color: 'black' } }}
+              InputProps={{ style: { color: 'black' } }}
+            />
+            <TextField
+              label="Feedback Quality"
+              value={quarterlyFields.feedbackQuality}
+              onChange={e => setQuarterlyFields(f => ({ ...f, feedbackQuality: e.target.value }))}
+              fullWidth
+              multiline
+              minRows={2}
+              sx={{ mb: 2, color: 'black' }}
+              InputLabelProps={{ style: { color: 'black' } }}
+              InputProps={{ style: { color: 'black' } }}
+            />
+            <Box display="flex" justifyContent="space-between" alignItems="center">
+              <Button variant="text" onClick={() => setQuarterlyModal({ open: false })} disabled={quarterlyModalLoading} sx={{ color: 'black' }}>
+                Cancel
+              </Button>
+              {quarterlyReviewId && (
+                <Button variant="outlined" color="error" onClick={handleDeleteQuarterlyReview} disabled={quarterlyModalLoading} sx={{ color: 'black', borderColor: 'black', '&:hover': { backgroundColor: '#f5c6cb' } }}>
+                  Delete Review
+                </Button>
+              )}
+              <Button variant="contained" color="primary" onClick={handleSaveQuarterlyReview} disabled={quarterlyModalLoading} sx={{ color: '#fff', backgroundColor: '#1976d2', '&:hover': { backgroundColor: '#1565c0' } }}>
                 Save
               </Button>
             </Box>


### PR DESCRIPTION
…hecks

- Add GET and POST endpoints for quarterly reviews under objectives/[guid]/quarterly-reviews
- Enforce user-only access: only the objective owner can list or upsert quarterly reviews
- Use Next.js dynamic route params and NextAuth session for secure access control
- Support upsert logic for quarterly reviews (create or update by quarter/year/objective)
- Return appropriate error responses for unauthorized, forbidden, or not found cases
- Integrate with Prisma ObjectiveQuarterlyReview model and relations