### PR TITLE
feat: add protected profile page with SideNav and dashboard-style layout

### DIFF
--- a/src/app/profile/ProfileLayout.tsx
+++ b/src/app/profile/ProfileLayout.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React, { useState } from "react";
+import SideNav from "@/components/SideNav";
+import { Box, Typography, Paper } from "@mui/material";
+
+export default function ProfileLayout() {
+  const [sideNavOpen, setSideNavOpen] = useState(true);
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: 'black' }}>
+      <SideNav open={sideNavOpen} onClose={() => setSideNavOpen(false)} />
+      <Box component="main" sx={{ flexGrow: 1, p: { xs: 2, md: 6 }, display: 'flex', flexDirection: 'column', alignItems: 'center', bgcolor: 'black', minHeight: '100vh' }}>
+        <Paper elevation={2} sx={{ width: '100%', maxWidth: 900, p: { xs: 2, md: 4 }, mt: 4, borderRadius: 3, boxShadow: 3 }}>
+          <Typography variant="h4" fontWeight="bold" gutterBottom>
+            Profile Page
+          </Typography>
+          {/* Add more profile details here in the future */}
+        </Paper>
+      </Box>
+    </Box>
+  );
+}

--- a/src/app/profile/__tests__/ProfileLayout.test.tsx
+++ b/src/app/profile/__tests__/ProfileLayout.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import ProfileLayout from "../ProfileLayout";
+
+jest.mock("@/components/SideNav", () => ({
+  __esModule: true,
+  default: (props: any) => <nav data-testid="sidenav" {...props} />,
+}));
+
+describe("ProfileLayout", () => {
+  it("renders the profile page heading", () => {
+    render(<ProfileLayout />);
+    expect(screen.getByRole("heading", { name: /profile page/i })).toBeInTheDocument();
+  });
+
+  it("renders the SideNav component", () => {
+    render(<ProfileLayout />);
+    expect(screen.getByTestId("sidenav")).toBeInTheDocument();
+  });
+
+  it("renders the Paper container", () => {
+    render(<ProfileLayout />);
+    expect(screen.getByText(/profile page/i).closest(".MuiPaper-root")).toBeInTheDocument();
+  });
+});

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,12 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/auth/authOptions";
+import { redirect } from "next/navigation";
+import ProfileLayout from "./ProfileLayout";
+
+export default async function ProfilePage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect("/api/auth/signin");
+  }
+  return <ProfileLayout />;
+}


### PR DESCRIPTION
- Create /profile route with server-side NextAuth session check and redirect for unauthenticated users
- Add ProfileLayout client component with SideNav, central Paper box, and black background to match dashboard style
- Implement responsive, accessible MUI layout for profile content
- Add tests for ProfileLayout: heading, SideNav, and Paper container rendering