### PR TITLE
Highlight active page in SideNav and fix logout redirect

### DIFF
--- a/src/app/my-job-role/page.tsx
+++ b/src/app/my-job-role/page.tsx
@@ -4,6 +4,7 @@ import WorkOutlineIcon from "@mui/icons-material/WorkOutline";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import SideNav from "@/components/SideNav";
 
 export default function MyJobRolePage() {
   const { data: session, status } = useSession();
@@ -33,6 +34,9 @@ export default function MyJobRolePage() {
 
   return (
     <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: 'black' }}>
+      <Box sx={{ width: 240, flexShrink: 0 }}>
+        <SideNav open={true} onClose={() => {}} />
+      </Box>
       <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', py: 8 }}>
         <Paper elevation={2} sx={{ maxWidth: 600, width: '100%', p: 4, textAlign: "center", bgcolor: 'white', mb: 4 }}>
           <WorkOutlineIcon sx={{ fontSize: 48, mb: 2, color: "primary.main" }} />

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -15,6 +15,7 @@ import WorkOutlineIcon from "@mui/icons-material/WorkOutline";
 import { useTheme, useMediaQuery } from "@mui/material";
 import NextLink from "next/link";
 import { signOut, useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
 
 const navLinks = [
   { text: "Profile", icon: <PersonIcon />, href: "/profile" },
@@ -35,6 +36,7 @@ const SideNav: React.FC<SideNavProps> = ({ open, onClose }) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const { data: session } = useSession();
   const isLineManager = !!(session?.user && (session.user as any).isLineManager);
+  const pathname = usePathname();
 
   return (
     <Drawer
@@ -69,16 +71,17 @@ const SideNav: React.FC<SideNavProps> = ({ open, onClose }) => {
       </Typography>
       <List>
         {navLinks.map((link) => {
+          const isActive = pathname === link.href;
           if (link.text === "Logout") {
             return (
-              <ListItem key={link.text} sx={{ cursor: 'pointer' }} onClick={() => { signOut({ callbackUrl: window.location.origin }); onClose(); }}>
+              <ListItem key={link.text} sx={{ cursor: 'pointer', fontWeight: isActive ? 'bold' : undefined, backgroundColor: isActive ? '#e3f2fd' : undefined, color: isActive ? '#1976d2' : undefined, borderRadius: isActive ? 1 : undefined }} onClick={() => { signOut({ callbackUrl: "/" }); onClose(); }}>
                 <ListItemIcon>{link.icon}</ListItemIcon>
                 <ListItemText primary={link.text} />
               </ListItem>
             );
           }
           return (
-            <ListItem key={link.text} component={NextLink} href={link.href} onClick={onClose} sx={{ cursor: 'pointer' }}>
+            <ListItem key={link.text} component={NextLink} href={link.href} onClick={onClose} sx={{ cursor: 'pointer', fontWeight: isActive ? 'bold' : undefined, backgroundColor: isActive ? '#e3f2fd' : undefined, color: isActive ? '#1976d2' : undefined, borderRadius: isActive ? 1 : undefined }}>
               <ListItemIcon>{link.icon}</ListItemIcon>
               <ListItemText primary={link.text} />
             </ListItem>


### PR DESCRIPTION
SideNav now visually indicates the current active page using route-based highlighting. Logout now always redirects to the root (/) after sign out, preventing unwanted localhost redirects in production. Navigation and accessibility improved for all main links, including My Job Role.